### PR TITLE
Modify download link to archives

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -5,7 +5,7 @@ else
 end
 
 default["jetty"]["version"]   = "8.1.5.v20120716"
-default["jetty"]["link"]      = "http://download.eclipse.org/jetty/#{node['jetty']['version']}/dist/jetty-distribution-#{node['jetty']['version']}.tar.gz"
+default["jetty"]["link"]      = "http://archive.eclipse.org/jetty/#{node['jetty']['version']}/dist/jetty-distribution-#{node['jetty']['version']}.tar.gz"
 default["jetty"]["checksum"]  = "95d14a2937092f0e2ae5ac87ad5c306662fa2ce965f9b950dd0dc38730e32b4d" # SHA256
 default["jetty"]["directory"] = "/usr/local/src"
 default["jetty"]["download"]  = "#{node['jetty']['directory']}/jetty-distribution-#{node['jetty']['version']}.tar.gz"


### PR DESCRIPTION
Oracle decided to archive the version, we are using, which is available on a different URL.
